### PR TITLE
Run `poetry install` before running tests; set bash "strict mode"

### DIFF
--- a/pydantic_gen_and_test.sh
+++ b/pydantic_gen_and_test.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -euo pipefail
+IFS=$'\n\t'
+
 rm -rf ../pydantic-fhir
 poetry run fhirzeug  --output-directory ../pydantic-fhir --generator python_pydantic
 cd ../pydantic-fhir
+poetry install
 poetry run pytest tests -vv


### PR DESCRIPTION
Without running `poetry install` before `pytest` tests are failing. This PR also adds "bash strict mode". The most important part is `set -e`, which prevents the next line from running if the command in the previous one returned with not 0 exit code.