### PR TITLE
16 valuesets names are not unique

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+ignore = E203,E266,E501,W503,W504,E741
+exclude = .git,__pycache__,.venv,.downloads,fhirzeug/generators/python/,fhirzeug/generators/python_pydantic/templates/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,9 +47,15 @@ jobs:
         run: poetry install
         if: steps.cache.outputs.cache-hit != 'true'
 
-      # step by step
-      # - name: Code Quality Black
-      #   run: poetry run black . --check
+      # Code quality
+      - name: Code Quality Black
+        run: poetry run black . --check
+
+      - name: Code quality Flake8
+        run: poetry run flake8 .
+
+      - name: Typing check mypy
+        run: poetry run mypy .
 
       - name: Test with pytest
         run: poetry run pytest --cov=fhirzeug tests -n 2 --cov-report xml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,6 +73,8 @@ jobs:
           poetry run fhirzeug  --output-directory pydantic-fhir --generator python_pydantic
           cd pydantic-fhir
           poetry install
+          # Check for duplicated classes
+          poetry run flake8 --select=F811 pydantic_fhir/r4.py
           # execute all tests except to ones we excpect to fail
           # I got the via `./pydantic_gen_and_test.sh | grep FAILED`
           poetry run pytest tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,6 +67,8 @@ jobs:
           poetry run fhirzeug  --output-directory pydantic-fhir --generator python_pydantic
           cd pydantic-fhir
           poetry install
+          # Check for duplicated classes
+          poetry run flake8 --select=F811 pydantic_fhir/r4.py
           # execute all tests except to ones we excpect to fail
           # I got the via `./pydantic_gen_and_test.sh | grep FAILED`
           poetry run pytest tests

--- a/fhirzeug/cli.py
+++ b/fhirzeug/cli.py
@@ -1,4 +1,3 @@
-import sys
 import importlib
 from pathlib import Path
 
@@ -24,8 +23,8 @@ def main(
     dry_run: bool = False,
     load_only: bool = False,
     generator: str = "python_pydantic",
-    output_directory: Path = Path("output"),
-    download_cache: Path = Path("./downloads"),
+    output_directory: Path = Path("output"),  # noqa: B008
+    download_cache: Path = Path("./downloads"),  # noqa: B008
 ):
     """Download and parse FHIR resource definitions."""
 
@@ -38,10 +37,13 @@ def main(
     generator_path = Path(generator_settings.__file__).parent
     generator_config = load_generator_config(generator_path.joinpath("generator.yaml"))
 
-    generator_settings.tpl_resource_target = str(output_directory)
+    generator_settings.tpl_resource_target = str(output_directory)  # type: ignore
 
     # assure we have all files
-    loader = SpecificationCache(generator_settings.specification_url, download_cache)
+    loader = SpecificationCache(
+        generator_settings.specification_url,  # type: ignore
+        download_cache,
+    )
     loader.sync(force_download=force_download)
 
     # parse

--- a/fhirzeug/fhirrenderer.py
+++ b/fhirzeug/fhirrenderer.py
@@ -140,7 +140,8 @@ class FHIRStructureDefinitionRenderer(FHIRRenderer):
             current = work_stack.pop()
             for elm in derive_graph.get(current, []):
                 work_stack.append(elm.name)
-                classes.append(elm)
+                if elm not in classes:
+                    classes.append(elm)
 
         for clazz in classes:
             # classes = sorted(profile.writable_classes(), key=lambda x: x.name)

--- a/fhirzeug/generator.py
+++ b/fhirzeug/generator.py
@@ -8,8 +8,7 @@ from .generators.yaml_model import GeneratorConfig
 
 def generate(spec: FHIRSpec, output_directory: Path, generator_config: GeneratorConfig):
     """Generates code based on the spec and the generator.
-    
-    
+
     Args:
         spec: A parsed specification.
         output_directory: The directory where the output goes to.

--- a/fhirzeug/generators/default/mappings.py
+++ b/fhirzeug/generators/default/mappings.py
@@ -1,9 +1,11 @@
+import typing
+
 # Mappings for the FHIR class generator.
 #
 # This should be useable as-is for Python classes.
 
 # Which class names to map to resources and elements
-classmap = {
+classmap: typing.Dict[str, str] = {
     "Any": "Resource",
     "Practitioner.role": "PractRole",  # to avoid Practinioner.role and PractitionerRole generating the same class
     "boolean": "bool",
@@ -29,7 +31,7 @@ classmap = {
 }
 
 # Classes to be replaced with different ones at resource rendering time
-replacemap = {
+replacemap: typing.Dict[str, str] = {
     # "Reference": "FHIRReference",  # `FHIRReference` adds dereferencing capabilities
 }
 
@@ -37,7 +39,7 @@ replacemap = {
 natives = ["bool", "int", "float", "str", "dict", "decimal"]
 
 # Which classes are to be expected from JSON decoding
-jsonmap = {
+jsonmap: typing.Dict[str, str] = {
     "str": "str",
     "int": "int",
     "bool": "bool",
@@ -47,7 +49,7 @@ jsonmap = {
 jsonmap_default = "dict"
 
 # Properties that need to be renamed because of language keyword conflicts
-reservedmap = {
+reservedmap: typing.Dict[str, str] = {
     "for": "for_",
     "from": "from_",
     "class": "class_",
@@ -64,7 +66,7 @@ reservedmap = {
 }
 
 # For enum codes where a computer just cannot generate reasonable names
-enum_map = {
+enum_map: typing.Dict[str, str] = {
     "=": "eq",
     "!=": "ne",
     "<": "lt",
@@ -75,11 +77,11 @@ enum_map = {
 }
 
 # If you want to give specific names to enums based on their URI
-enum_namemap = {
+enum_namemap: typing.Dict[str, str] = {
     # 'http://hl7.org/fhir/coverage-exception': 'CoverageExceptionCodes',
 }
 
 # If certain CodeSystems don't need to generate an enum
-enum_ignore = {
+enum_ignore: typing.Dict[str, str] = {
     # 'http://hl7.org/fhir/resource-type-link',
 }

--- a/fhirzeug/generators/default/mappings.py
+++ b/fhirzeug/generators/default/mappings.py
@@ -78,7 +78,19 @@ enum_map: typing.Dict[str, str] = {
 
 # If you want to give specific names to enums based on their URI
 enum_namemap: typing.Dict[str, str] = {
-    # 'http://hl7.org/fhir/coverage-exception': 'CoverageExceptionCodes',
+    "http://terminology.hl7.org/CodeSystem/composition-altcode-kind": "CompositionAltcodeKind",
+    "http://terminology.hl7.org/CodeSystem/codesystem-altcode-kind": "CodesystemAltcodeKind",
+    "http://hl7.org/fhir/contract-security-category": "ContractSecurityCategoryCodes",
+    "http://hl7.org/fhir/contract-security-classification": "ContractSecurityClassificationCodes",
+    "http://hl7.org/fhir/contract-scope": "ContractScopeCodes",
+    "http://hl7.org/fhir/device-definition-status": "FHIRDeviceDefinitionStatus",
+    "http://hl7.org/fhir/device-status": "FHIRDeviceStatus",
+    "http://hl7.org/fhir/CodeSystem/medication-statement-status": "MedicationStatementStatusCodes",
+    "http://hl7.org/fhir/CodeSystem/medication-status": "MedicationStatusCodes",
+    "http://terminology.hl7.org/CodeSystem/observation-category": "ObservationCategoryCodes",
+    "http://hl7.org/fhir/secondary-finding": "SecondaryFindingCodes",
+    # PractinionerRole is also a DomainResource
+    "http://terminology.hl7.org/CodeSystem/practitioner-role": "PractitionerRoleCodes",
 }
 
 # If certain CodeSystems don't need to generate an enum

--- a/fhirzeug/generators/default/mappings.py
+++ b/fhirzeug/generators/default/mappings.py
@@ -76,7 +76,19 @@ enum_map = {
 
 # If you want to give specific names to enums based on their URI
 enum_namemap = {
-    # 'http://hl7.org/fhir/coverage-exception': 'CoverageExceptionCodes',
+    "http://terminology.hl7.org/CodeSystem/composition-altcode-kind": "CompositionAltcodeKind",
+    "http://terminology.hl7.org/CodeSystem/codesystem-altcode-kind": "CodesystemAltcodeKind",
+    "http://hl7.org/fhir/contract-security-category": "ContractSecurityCategoryCodes",
+    "http://hl7.org/fhir/contract-security-classification": "ContractSecurityClassificationCodes",
+    "http://hl7.org/fhir/contract-scope": "ContractScopeCodes",
+    "http://hl7.org/fhir/device-definition-status": "FHIRDeviceDefinitionStatus",
+    "http://hl7.org/fhir/device-status": "FHIRDeviceStatus",
+    "http://hl7.org/fhir/CodeSystem/medication-statement-status": "MedicationStatementStatusCodes",
+    "http://hl7.org/fhir/CodeSystem/medication-status": "MedicationStatusCodes",
+    "http://terminology.hl7.org/CodeSystem/observation-category": "ObservationCategoryCodes",
+    "http://hl7.org/fhir/secondary-finding": "SecondaryFindingCodes",
+    # PractinionerRole is also a DomainResource
+    "http://terminology.hl7.org/CodeSystem/practitioner-role": "PractitionerRoleCodes",
 }
 
 # If certain CodeSystems don't need to generate an enum

--- a/fhirzeug/generators/default/settings.py
+++ b/fhirzeug/generators/default/settings.py
@@ -3,7 +3,7 @@
 # indicate directories: the parser will split them on '/' and use os.path to
 # make them platform independent.
 
-from .mappings import *
+from .mappings import *  # noqa: F401, F403
 
 
 # Base URL for where to load specification data from
@@ -18,13 +18,17 @@ tpl_base = "Sample"
 
 # Whether and where to put the generated class models
 write_resources = True
-tpl_resource_source = "resource.py.jinja2"  # the template to use as source when writing resource implementations for profiles
+# the template to use as source when writing resource implementations for profiles
+tpl_resource_source = "resource.py.jinja2"
 tpl_resource_target = (
     "../models"  # target directory to write the generated class files to
 )
-tpl_resource_target_ptrn = "{}.py"  # target class file name pattern, with one placeholder (`{}`) for the class name
-tpl_codesystems_source = "codesystems.py.jinja2"  # the template to use as source when writing enums for CodeSystems; can be `None`
-tpl_codesystems_target_ptrn = "{}.py"  # the filename pattern to use for generated code systems and value sets, with one placeholder (`{}`) for the class name
+# target class file name pattern, with one placeholder (`{}`) for the class name
+tpl_resource_target_ptrn = "{}.py"
+# the template to use as source when writing enums for CodeSystems; can be `None`
+tpl_codesystems_source = "codesystems.py.jinja2"
+# the filename pattern to use for generated code systems and value sets, with one placeholder (`{}`) for the class name
+tpl_codesystems_target_ptrn = "{}.py"
 
 # Whether and where to put the factory methods and the dependency graph
 write_factory = True
@@ -48,13 +52,11 @@ tpl_unittest_source = (
 tpl_unittest_target = (
     "../models"  # target directory to write the generated unit test files to
 )
-tpl_unittest_target_ptrn = "{}_tests.py"  # target file name pattern for unit tests; the one placeholder (`{}`) will be the class name
-unittest_copyfiles = (
-    []
-)  # array of file names to copy to the test directory `tpl_unittest_target` (e.g. unit test base classes)
 
-unittest_format_path_prepare = "{}"  # used to format `path` before appending another path element - one placeholder for `path`
-unittest_format_path_key = "{}.{}"  # used to create property paths by appending `key` to the existing `path` - two placeholders
+# used to format `path` before appending another path element - one placeholder for `path`
+unittest_format_path_prepare = "{}"
+# used to create property paths by appending `key` to the existing `path` - two placeholders
+unittest_format_path_key = "{}.{}"
 unittest_format_path_index = (
     "{}[{}]"  # used for array properties - two placeholders, `path` and the array index
 )

--- a/fhirzeug/generators/python/settings.py
+++ b/fhirzeug/generators/python/settings.py
@@ -15,11 +15,13 @@ write_resources = True
 tpl_resource_target = (
     "./fhirclient/models"  # target directory to write the generated class files to
 )
-tpl_codesystems_source = None  # the template to use as source when writing enums for CodeSystems; can be `None`
+# the template to use as source when writing enums for CodeSystems; can be `None`
+tpl_codesystems_source = "None"
 
 # factory methods
 write_factory = True
-tpl_factory_target = "../fhirclient/models/fhirelementfactory.py"  # where to write the generated factory to
+# where to write the generated factory to
+tpl_factory_target = "../fhirclient/models/fhirelementfactory.py"
 
 # unit tests
 write_unittests = False

--- a/fhirzeug/generators/python_pydantic/settings.py
+++ b/fhirzeug/generators/python_pydantic/settings.py
@@ -2,7 +2,7 @@
 # All paths are relative to the `fhir-parser` directory. You may want to use
 # os.path.join() if the generator should work on Windows, too.
 
-from ..default.settings import *
+from ..default.settings import *  # noqa: F401, F403
 
 # Base URL for where to load specification data from
 specification_url = "http://hl7.org/fhir/R4"
@@ -15,11 +15,13 @@ write_resources = True
 tpl_resource_target = (
     "./fhirclient/models"  # target directory to write the generated class files to
 )
-tpl_codesystems_source = "codesystems.py.jinja2"  # the template to use as source when writing enums for CodeSystems; can be `None`
+# the template to use as source when writing enums for CodeSystems; can be `None`
+tpl_codesystems_source = "codesystems.py.jinja2"
 
 # factory methods
 write_factory = True
-tpl_factory_target = "../fhirclient/models/fhirelementfactory.py"  # where to write the generated factory to
+# where to write the generated factory to
+tpl_factory_target = "../fhirclient/models/fhirelementfactory.py"
 
 # unit tests
 write_unittests = False

--- a/fhirzeug/generators/python_pydantic/templates/codesystems.py.jinja2
+++ b/fhirzeug/generators/python_pydantic/templates/codesystems.py.jinja2
@@ -1,5 +1,5 @@
 
-# this inherits from string as well so we can serialzie it correctly with pydantic
+# this inherits from string as well so we can serialize it correctly with pydantic
 class {{system.name}}(str, DocEnum):
     {% for code in system.codes %}
     {{code.name}} = "{{code.code}}", """{{code.definition}} """

--- a/fhirzeug/generators/python_pydantic/templates/resource_header.py
+++ b/fhirzeug/generators/python_pydantic/templates/resource_header.py
@@ -16,7 +16,7 @@ def choice_of_validator(choices, optional):
         if setted_values > 1:
             raise ValueError(f"Only one of the fields is allowed to be set ({choices})")
         elif not optional and setted_values < 1:
-            raise ValueError(f"A t least one of the fields needs to be set ({choices})")
+            raise ValueError(f"At least one of the fields needs to be set ({choices})")
         return values
 
     return check_at_least_one
@@ -24,10 +24,10 @@ def choice_of_validator(choices, optional):
 
 def camelcase_alias_generator(name: str) -> str:
     """Maps snakecase to camelcase.
-    
+
     This enables members to be created from camelCase. It takes the existing camelcase membername
     like foo_bar and converts it to its camelcase pedant fooBar.
-    
+
     Additionally it removes trailing _, since this is used to make membernames of reserved keywords
     usable, like `class`.
     """
@@ -44,7 +44,7 @@ class DocEnum(enum.Enum):
 
     def __new__(cls, value, doc=None):
         """add docstring to the member of Enum if exists
-        
+
         Args:
             value: Enum member value
             doc: Enum member docstring, None if not exists

--- a/fhirzeug/generators/yaml_model.py
+++ b/fhirzeug/generators/yaml_model.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 
 class CopyTarget(BaseModel):
     """A target to copy a file.
-    
+
     Attributes:
         destination: path where the file should copied to
     """
@@ -25,9 +25,9 @@ class Template(BaseModel):
 
 class GeneratorConfig(BaseModel):
     """Config for the generator. Each Generator for each language has one.
-    
+
     Attributes:
-        copy_examples: Target of where the 
+        copy_examples: Target of where the
         templates: *not in used yes*
         output_file: Where the generate file will be pushed.
     """

--- a/fhirzeug/logger.py
+++ b/fhirzeug/logger.py
@@ -7,7 +7,7 @@ def setup_logging():
 
     logging.root.setLevel(log_level)
     try:
-        from colorlog import ColoredFormatter
+        from colorlog import ColoredFormatter  # type: ignore
 
         logfmt = "  %(log_color)s%(levelname)-8s%(reset)s | %(log_color)s%(message)s%(reset)s"
         formatter = ColoredFormatter(logfmt)
@@ -19,7 +19,7 @@ def setup_logging():
         logger = logging.getLogger("fhirparser")
         logger.setLevel(log_level)
         logger.addHandler(stream)
-    except Exception as e:
+    except Exception:
         logging.info('Install "colorlog" to enable colored log messages')
 
 

--- a/fhirzeug/specificationcache.py
+++ b/fhirzeug/specificationcache.py
@@ -1,10 +1,8 @@
-import io
 from pathlib import Path
-import os.path
+import requests
 import shutil
 import zipfile
 
-import requests
 
 from .logger import logger
 
@@ -18,7 +16,7 @@ def safe_pathname(filename: str) -> str:
 
 class SpecificationCache(object):
     """ Class to download, cache and manage specifications.
-    
+
     Attributes:
         needs   The pre known content of a file
     """
@@ -32,9 +30,9 @@ class SpecificationCache(object):
         self.base_url = base_url
         self.cache_dir = cache_dir.joinpath(safe_pathname(base_url))
 
-    def sync(self, force_download: bool = False) -> Path:
+    def sync(self, force_download: bool = False):
         """ Makes sure all the files needed have been downloaded.
-        
+
         :returns: The path to the directory with all our files.
         """
 
@@ -60,7 +58,7 @@ class SpecificationCache(object):
 
     def download(self, remote: str, local: Path) -> None:
         """ Download the given file located on the server.
-        
+
         :returns: The local file name in our cache directory the file was
             downloaded to
         """

--- a/pydantic_gen_and_test.sh
+++ b/pydantic_gen_and_test.sh
@@ -8,4 +8,5 @@ rm -rf ../pydantic-fhir
 poetry run fhirzeug  --output-directory ../pydantic-fhir --generator python_pydantic
 cd ../pydantic-fhir
 poetry install
+poetry run flake8 --select=F811 pydantic_fhir/r4.py
 poetry run pytest tests -vv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,5 @@ fhirzeug = "fhirzeug.cli:app"
 requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"
 
+[tool.black]
+exclude = "fhirzeug/generators/python/|fhirzeug/generators/python_pydantic/templates/"

--- a/tests/pydantic/test_alias_generator.py
+++ b/tests/pydantic/test_alias_generator.py
@@ -1,4 +1,3 @@
-import pytest
 import pydantic
 from fhirzeug.generators.python_pydantic.templates.resource_header import (
     camelcase_alias_generator,

--- a/tests/pydantic/test_basic_types_pyd.py
+++ b/tests/pydantic/test_basic_types_pyd.py
@@ -1,5 +1,4 @@
 import typing
-import inspect
 import decimal
 import base64
 
@@ -43,7 +42,7 @@ def test_fhirdate():
         model = ExampleModel(date="1973-06-33")
     model = ExampleModel(date="2018")
     model = ExampleModel(date="1973-06")
-    model = ExampleModel(date="1905-08-23")
+    model = ExampleModel(date="1905-08-23")  # noqa : F841
 
 
 def test_fhirdatetime():
@@ -61,7 +60,7 @@ def test_fhirdatetime():
     model = ExampleModel(datetime="1973-06")
     model = ExampleModel(datetime="1905-08-23")
     model = ExampleModel(datetime="2015-02-07T13:28:17-05:00")
-    model = ExampleModel(datetime="2017-01-01T00:00:00.000Z")
+    model = ExampleModel(datetime="2017-01-01T00:00:00.000Z")  # noqa : F841
 
 
 def test_fhirtime():
@@ -73,7 +72,7 @@ def test_fhirtime():
         model = ExampleModel(time="24:00")
     with pytest.raises(pydantic.ValidationError):
         model = ExampleModel(time="13:28:17-05:00")
-    model = ExampleModel(time="17:00:00")
+    model = ExampleModel(time="17:00:00")  # noqa : F841
 
 
 def test_fhirinstant():
@@ -84,24 +83,24 @@ def test_fhirinstant():
     with pytest.raises(pydantic.ValidationError):
         model = ExampleModel(instant="24:00")
     model = ExampleModel(instant="2017-01-01T00:00:00Z")
-    model = ExampleModel(instant="2015-02-07T13:28:17.239+02:00")
+    model = ExampleModel(instant="2015-02-07T13:28:17.239+02:00")  # noqa : F841
 
 
 def test_fhirbase64binary():
     """Test FHIRBase64Binary
     https://www.hl7.org/fhir/datatypes.html#base64binary"""
+
     message = "Foo Bar"
     message_bytes = message.encode("ascii")
     base64_bytes = base64.b64encode(message_bytes)
     base64_message = base64_bytes.decode("ascii")
     model = ExampleModel(base64=base64_message)
-
     with pytest.raises(pydantic.ValidationError):
         model = ExampleModel(base64=message)
 
     model = ExampleModel(base64="2jmj7l5rSw0yVb/vlWAYkK/YBwk=")
     with pytest.raises(pydantic.ValidationError):
-        model = ExampleModel(base64="2jmj7l5rSw0yVb/vlWAYkK/YBwk")
+        model = ExampleModel(base64="2jmj7l5rSw0yVb/vlWAYkK/YBwk")  # noqa : F841
 
 
 def test_fhiroid():
@@ -110,7 +109,7 @@ def test_fhiroid():
 
     model = ExampleModel(oid="urn:oid:1.2.3.4.5")
     with pytest.raises(pydantic.ValidationError):
-        model = ExampleModel(oid="foo")
+        model = ExampleModel(oid="foo")  # noqa : F841
 
 
 def test_fhirid():
@@ -119,13 +118,13 @@ def test_fhirid():
 
     model = ExampleModel(fhir_id="foo.bar")
     with pytest.raises(pydantic.ValidationError):
-        model = ExampleModel(fhir_id="?")
+        model = ExampleModel(fhir_id="?")  # noqa : F841
 
 
 def test_decimal():
     """Test FHIRDecimal
     https://www.hl7.org/fhir/datatypes.html#decimal"""
+
     with pytest.raises(pydantic.ValidationError):
         model = ExampleModel(decimal="FOO")
-
-    model = ExampleModel(decimal=3.14000000000000012434497875801)
+    model = ExampleModel(decimal=3.14000000000000012434497875801)  # noqa : F841

--- a/tests/pydantic/test_choice_of_datatypes_pyd.py
+++ b/tests/pydantic/test_choice_of_datatypes_pyd.py
@@ -1,12 +1,10 @@
-from fhirzeug.fhirspec import FHIRSpec
 from fhirzeug.generators.python_pydantic.templates.resource_header import (
     choice_of_validator,
 )
-from pprint import pprint
 
 import pytest
 
-from pydantic import BaseModel, ValidationError, validator, root_validator
+from pydantic import BaseModel, ValidationError, root_validator
 from typing import Optional
 
 

--- a/tests/pydantic/test_nullability.py
+++ b/tests/pydantic/test_nullability.py
@@ -1,5 +1,4 @@
 import typing
-import pydantic
 
 from fhirzeug.generators.python_pydantic.templates.resource_header import (
     FHIRAbstractBase,
@@ -33,7 +32,7 @@ class RootModel(FHIRAbstractBase):
 
 
 def test_returns_none_if_no_fields():
-    assert RootModel().dict() == None
+    assert RootModel().dict() is None
 
 
 def test_not_set_fields_are_ignored():
@@ -66,8 +65,8 @@ def test_empty_lists_are_ignored():
         "field_a": "a",
     }
     assert RootModel(
-        field_a="a", list_items=[ListItem(), ListItem(), ListItem(),]
-    ).dict() == {"field_a": "a",}
+        field_a="a", list_items=[ListItem(), ListItem(), ListItem()]
+    ).dict() == {"field_a": "a"}
 
 
 def test_non_empty_list_items_are_serialized():

--- a/tests/test_choice_of_datatypes.py
+++ b/tests/test_choice_of_datatypes.py
@@ -1,31 +1,25 @@
 """A few elements have a choice of more than one data type for their content.
 
- All such elements have a name that takes the form nnn[x]. The "nnn" part of the name is constant, 
- and the "[x]" is replaced with the title-cased name of the type that is actually used. The table 
+ All such elements have a name that takes the form nnn[x]. The "nnn" part of the name is constant,
+ and the "[x]" is replaced with the title-cased name of the type that is actually used. The table
  view shows each of these names explicitly.
 
-Elements that have a choice of data type cannot repeat - they must have a maximum cardinality of 1. 
+Elements that have a choice of data type cannot repeat - they must have a maximum cardinality of 1.
 When constructing an instance of an element with a choice of types, the authoring system must create
  a single element with a data type chosen from among the list of permitted data types.
 
 Note: In object-orientated implementations, this is naturally represented as a polymorphic property.
- However this is not necessary and the correct implementation varies according to the particular 
- features of the language. In XML schema, these become an xs:choice of element. To help with code 
+ However this is not necessary and the correct implementation varies according to the particular
+ features of the language. In XML schema, these become an xs:choice of element. To help with code
  generation, a list of choice elements is published.
 
 
-These tests here use the capability statement because it is relatively small to isolate the cases 
+These tests here use the capability statement because it is relatively small to isolate the cases
 quite well.
 """
 
 
 from fhirzeug.fhirspec import FHIRSpec
-from pprint import pprint
-
-import pytest
-
-from pydantic import BaseModel, ValidationError, validator, root_validator
-from typing import Optional
 
 
 # the validator needs to be moved into a pydantic generator section

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -1,6 +1,3 @@
-import pytest
-
-
 from fhirzeug.generators.python_pydantic.templates.resource_header import DocEnum
 from fhirzeug.fhirspec import FHIRSpec
 

--- a/tests/test_fhirspec.py
+++ b/tests/test_fhirspec.py
@@ -1,20 +1,17 @@
 import os
-import pytest
 
 
 from fhirzeug.fhirspec import (
     FHIRSpec,
-    FHIRStructureDefinitionStructure,
     FHIRVersionInfo,
 )
-from fhirzeug.fhirclass import FHIRClass
 
 
 def test_writable_profiles(spec: FHIRSpec):
     check = any(
         item in spec.settings.manual_profiles for item in spec.writable_profiles()
     )
-    assert check == False
+    assert check is False
 
 
 def test_read_version(spec: FHIRSpec):
@@ -49,3 +46,11 @@ def test_as_class_name(spec: FHIRSpec):
 def test_class_name_for_type_if_property(spec: FHIRSpec):
     class_name = spec.class_name_for_type_if_property("")
     assert class_name is None
+
+
+def test_class_name_for_profile(spec: FHIRSpec):
+    profile_name = "http://hl7.org/fhir/Profile/MyProfile"
+    class_name = "MyProfile"
+    assert spec.class_name_for_profile(None) is None
+    assert spec.class_name_for_profile(profile_name) == class_name
+    assert spec.class_name_for_profile([profile_name]) == [class_name]

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,4 +1,3 @@
-from filecmp import dircmp
 from pathlib import Path
 
 from fhirzeug.generator import generate


### PR DESCRIPTION
Close #16 .

Selected solution has been to use the `enum_namemap` dictionary to deduplicate classes.

I have added a test in the pipeline to check that all classes are defined only once in the generated r4.py file, using flake8. For now it doesn't pass the test due to the duplicated `Quantity` resource. This is a separate issue addressed by #31 .