### PR TITLE
Accept both dictionnary and resources in Resource attributes

### DIFF
--- a/fhirzeug/generators/python_pydantic/static_files/pyproject.toml
+++ b/fhirzeug/generators/python_pydantic/static_files/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydantic-fhir"
-version = "0.0.1-alpha10"
+version = "0.0.1-alpha11"
 description = "Generated FHIR model for Pydantic."
 readme = "README.md"
 authors = ["Skalar Systems <contact@skalarsystems.com>"]

--- a/fhirzeug/generators/python_pydantic/static_files/tests/test_examples/test_basic.py
+++ b/fhirzeug/generators/python_pydantic/static_files/tests/test_examples/test_basic.py
@@ -1,6 +1,3 @@
-import typing
-
-
 from pydantic_fhir import r4
 
 

--- a/fhirzeug/generators/python_pydantic/static_files/tests/test_examples/test_basic.py
+++ b/fhirzeug/generators/python_pydantic/static_files/tests/test_examples/test_basic.py
@@ -1,0 +1,12 @@
+import typing
+
+
+from pydantic_fhir import r4
+
+
+def test_bundle_entry_instanciation() -> None:
+    """Test that BundleEntry can be created with an existing Resource."""
+    issue = r4.OperationOutcomeIssue(code="not-found", severity="warning")
+    outcome = r4.OperationOutcome(issue=[issue])
+    entry = r4.BundleEntry(resource=outcome)
+    assert entry.resource.issue[0].code == "not-found"

--- a/fhirzeug/generators/python_pydantic/templates/resource.py.jinja2
+++ b/fhirzeug/generators/python_pydantic/templates/resource.py.jinja2
@@ -52,6 +52,8 @@ class {{ clazz.name }}({{ clazz.superclass.name|default('object')}}):
 {%- if prop.desired_classname == "Resource" %}
     @pydantic.validator("{{ prop.name | snake_case }}", pre=True,  each_item=True)
     def resource_factory(cls, value):
+        if isinstance(value, Resource):
+            return value
         return from_dict(value)
 {%- endif %}
 {% endfor %}


### PR DESCRIPTION
Closes #45 .

Solve issue for `BundleEntry`.and `ParametersParameter` objects (the only 2 resources containing resources).

I updated the pydantic_fhir version in order to push new release.