### PR TITLE
Add validators for int, unsigned int and positive int types

### DIFF
--- a/fhirzeug/generators/default/generator.yaml
+++ b/fhirzeug/generators/default/generator.yaml
@@ -90,9 +90,9 @@ mapping_rules:
     Any: Resource
     Practitioner.role: PractRole  # to avoid Practinioner.role and PractitionerRole generating the same class
     boolean: bool
-    integer: int
-    positiveInt: int
-    unsignedInt: int
+    integer: FHIRInt
+    positiveInt: FHIRPositiveInt
+    unsignedInt: FHIRUnsignedInt
     date: FHIRDate
     dateTime: FHIRDateTime
     instant: FHIRInstant

--- a/fhirzeug/generators/python_pydantic/static_files/tests/test_examples/test_basic.py
+++ b/fhirzeug/generators/python_pydantic/static_files/tests/test_examples/test_basic.py
@@ -26,4 +26,4 @@ def test_int_types() -> None:
         timing_repeat = r4.TimingRepeat(offset=1.0)
 
     with pytest.raises(pydantic.ValidationError):
-        timing_repeat = r4.TimingRepeat(count=0)
+        timing_repeat = r4.TimingRepeat(count=0)  # noqa : F841

--- a/fhirzeug/generators/python_pydantic/static_files/tests/test_examples/test_basic.py
+++ b/fhirzeug/generators/python_pydantic/static_files/tests/test_examples/test_basic.py
@@ -1,3 +1,5 @@
+import pytest
+import pydantic
 from pydantic_fhir import r4
 
 
@@ -7,3 +9,21 @@ def test_bundle_entry_instanciation() -> None:
     outcome = r4.OperationOutcome(issue=[issue])
     entry = r4.BundleEntry(resource=outcome)
     assert entry.resource.issue[0].code == "not-found"
+
+
+def test_int_types() -> None:
+    """Test that FHIRInt types are used in Resources.
+
+    `count` must be a FHIRPositiveInt
+    `offset` must be a FHIRUnsignedInt
+    """
+    timing_repeat = r4.TimingRepeat(count=1, offset=1)
+
+    with pytest.raises(pydantic.ValidationError):
+        timing_repeat = r4.TimingRepeat(offset=-1)
+
+    with pytest.raises(pydantic.ValidationError):
+        timing_repeat = r4.TimingRepeat(offset=1.0)
+
+    with pytest.raises(pydantic.ValidationError):
+        timing_repeat = r4.TimingRepeat(count=0)

--- a/fhirzeug/generators/python_pydantic/templates/fhir_basic_types.py
+++ b/fhirzeug/generators/python_pydantic/templates/fhir_basic_types.py
@@ -35,12 +35,6 @@ FHIRId = exact_regex_constr(regex=r"[A-Za-z0-9\-\.]{1,64}")
 
 FHIRBase64Binary = exact_regex_constr(regex=r"(\s*([0-9a-zA-Z\+/=]){4}\s*)+")
 
-FHIRInt = pydantic.conint(strict=True)
-
-FHIRUnsignedInt = pydantic.conint(strict=True, ge=0)
-
-FHIRPositiveInt = pydantic.conint(strict=True, gt=0)
-
 
 def validate_factory(cls):
     def validate_int_string(v):

--- a/fhirzeug/generators/python_pydantic/templates/fhir_basic_types.py
+++ b/fhirzeug/generators/python_pydantic/templates/fhir_basic_types.py
@@ -1,9 +1,14 @@
+import re
 import pydantic
+
+
+def exact_regex(regex):
+    return r"\A" + regex.lstrip(r"\A").rstrip(r"\Z") + r"\Z"
 
 
 def exact_regex_constr(**kwargs):
     if kwargs.get("regex") is not None:
-        kwargs["regex"] = r"\A" + kwargs["regex"].lstrip(r"\A").rstrip(r"\Z") + r"\Z"
+        kwargs["regex"] = exact_regex(kwargs["regex"])
     return pydantic.constr(**kwargs)
 
 
@@ -29,3 +34,67 @@ FHIROid = exact_regex_constr(regex=r"urn:oid:[0-2](\.(0|[1-9][0-9]*))+")
 FHIRId = exact_regex_constr(regex=r"[A-Za-z0-9\-\.]{1,64}")
 
 FHIRBase64Binary = exact_regex_constr(regex=r"(\s*([0-9a-zA-Z\+/=]){4}\s*)+")
+
+FHIRInt = pydantic.conint(strict=True)
+
+FHIRUnsignedInt = pydantic.conint(strict=True, ge=0)
+
+FHIRPositiveInt = pydantic.conint(strict=True, gt=0)
+
+
+def validate_factory(cls):
+    def validate_int_string(v):
+        """Validate a string given a FHIR regex."""
+        if isinstance(v, str):
+            if re.match(exact_regex(cls.REGEX), v) is None:
+                msg = f"String does not match {cls.__name__} pattern : {cls.REGEX}"
+                raise ValueError(msg)
+            return int(v)
+        return v
+
+    return validate_int_string
+
+
+class FHIRInt(pydantic.conint(strict=True)):
+    """Integer field following FHIR specs.
+
+    https://www.hl7.org/fhir/datatypes.html#integer
+    """
+
+    REGEX = "[0]|[-+]?[1-9][0-9]*"
+
+    @classmethod
+    def __get_validators__(cls):
+        yield validate_factory(cls)
+        yield from super(FHIRInt, cls).__get_validators__()
+
+
+class FHIRUnsignedInt(pydantic.conint(strict=True, ge=0)):
+    """Unsigned integer field following FHIR specs.
+
+    https://www.hl7.org/fhir/datatypes.html#unsignedInt
+    """
+
+    REGEX = "[0]|([1-9][0-9]*)"
+
+    @classmethod
+    def __get_validators__(cls):
+        yield validate_factory(cls)
+        yield from super(FHIRUnsignedInt, cls).__get_validators__()
+
+
+class FHIRPositiveInt(pydantic.conint(strict=True, gt=0)):
+    """Positive integer field following FHIR specs.
+
+    Warning : FHIR Spec regex : "+?[1-9][0-9]*" seems invalid
+              I think that intended use is "[+]?[1-9][0-9]*"
+
+    https://www.hl7.org/fhir/datatypes.html#positiveInt
+    """
+
+    REGEX = "[+]?[1-9][0-9]*"
+
+    @classmethod
+    def __get_validators__(cls):
+        yield validate_factory(cls)
+        yield from super(FHIRPositiveInt, cls).__get_validators__()

--- a/tests/pydantic/test_basic_types_pyd.py
+++ b/tests/pydantic/test_basic_types_pyd.py
@@ -17,6 +17,9 @@ from fhirzeug.generators.python_pydantic.templates.fhir_basic_types import (
     FHIRBase64Binary,
     FHIRId,
     FHIROid,
+    FHIRInt,
+    FHIRUnsignedInt,
+    FHIRPositiveInt,
 )
 
 
@@ -32,6 +35,9 @@ class ExampleModel(pydantic.BaseModel):
     oid: typing.Optional[FHIROid]
     fhir_id: typing.Optional[FHIRId]
     decimal: typing.Optional[decimal.Decimal]
+    fhir_int: typing.Optional[FHIRInt]
+    fhir_unsigned_int: typing.Optional[FHIRUnsignedInt]
+    fhir_positive_int: typing.Optional[FHIRPositiveInt]
 
 
 def test_fhirstring():
@@ -168,3 +174,78 @@ def test_decimal():
     with pytest.raises(pydantic.ValidationError):
         model = ExampleModel(decimal="FOO")
     model = ExampleModel(decimal=3.14000000000000012434497875801)  # noqa : F841
+
+
+def test_fhir_int():
+    """Test FHIRInt
+    """
+    model = ExampleModel(fhir_int=-123456)
+    model = ExampleModel(fhir_int="-123456")
+    model = ExampleModel(fhir_int=0)
+    model = ExampleModel(fhir_int="0")
+    model = ExampleModel(fhir_int=123456)
+    model = ExampleModel(fhir_int="123456")
+    assert model.fhir_int == 123456
+
+    with pytest.raises(pydantic.ValidationError):
+        model = ExampleModel(fhir_int=1.234)
+
+    with pytest.raises(pydantic.ValidationError):
+        model = ExampleModel(fhir_int=0.0)
+
+    with pytest.raises(pydantic.ValidationError):
+        model = ExampleModel(fhir_int="-1.234")
+
+
+def test_fhir_unsigned_int():
+    """Test FHIRUnsignedInt
+    """
+    with pytest.raises(pydantic.ValidationError):
+        model = ExampleModel(fhir_unsigned_int=-123456)
+
+    with pytest.raises(pydantic.ValidationError):
+        model = ExampleModel(fhir_unsigned_int="-123456")
+
+    model = ExampleModel(fhir_unsigned_int=0)
+    model = ExampleModel(fhir_unsigned_int="0")
+    model = ExampleModel(fhir_unsigned_int=123456)
+    model = ExampleModel(fhir_unsigned_int="123456")
+    assert model.fhir_unsigned_int == 123456
+
+    with pytest.raises(pydantic.ValidationError):
+        model = ExampleModel(fhir_unsigned_int=1.234)
+
+    with pytest.raises(pydantic.ValidationError):
+        model = ExampleModel(fhir_unsigned_int=0.0)
+
+    with pytest.raises(pydantic.ValidationError):
+        model = ExampleModel(fhir_unsigned_int="-1.234")
+
+
+def test_fhir_positive_int():
+    """Test FHIRUnsignedInt
+    """
+    with pytest.raises(pydantic.ValidationError):
+        model = ExampleModel(fhir_positive_int=-123456)
+
+    with pytest.raises(pydantic.ValidationError):
+        model = ExampleModel(fhir_positive_int="-123456")
+
+    with pytest.raises(pydantic.ValidationError):
+        model = ExampleModel(fhir_positive_int=0)
+
+    with pytest.raises(pydantic.ValidationError):
+        model = ExampleModel(fhir_positive_int="0")
+
+    model = ExampleModel(fhir_positive_int=123456)
+    model = ExampleModel(fhir_positive_int="123456")
+    assert model.fhir_positive_int == 123456
+
+    with pytest.raises(pydantic.ValidationError):
+        model = ExampleModel(fhir_positive_int=1.234)
+
+    with pytest.raises(pydantic.ValidationError):
+        model = ExampleModel(fhir_positive_int=0.0)
+
+    with pytest.raises(pydantic.ValidationError):
+        model = ExampleModel(fhir_positive_int="-1.234")


### PR DESCRIPTION
Closes #47 .

Implement FHIRInt, FHIRPositiveInt and FHIRUnsignedInt types following FHIR specs (https://www.hl7.org/fhir/datatypes.html#primitive).