### PR TITLE
Handle unknown codesystems with known subsets 

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,25 @@ It will:
   - source files for python pydantic
   - a full python package also available (here)[https://pypi.org/project/pydantic-fhir/]).
 
+## Technical explanations
+
+### About ValueSets and CodeSystems
+
+Article to understand the difference in FHIR between a ValueSets and a CodeSystems : https://fhir-drills.github.io/ValueSet-And-CodeSystem.html .
+
+FHIR Specification provides different ways to define a ValueSet. At the moment, FHIRzeug implementation only handle a few cases :
+- If a ValueSet is based on a single CodeSystem and this CodeSystem is defined in FHIR, then a `DocEnum` object is generated to validate this ValueSet.  
+**Example :** ValueSet https://www.hl7.org/fhir/valueset-account-status.html is based on CodeSystem https://www.hl7.org/fhir/codesystem-account-status.html .
+- If a ValueSet is based on a single CodeSystem but this CodeSystem is not included in the FHIR specification, FHIRzeug do not implement it as an Enum. If FHIR provides an exhaustive list of possible values (e.g. : under `spec["compose"]["include"][0]["concept"]`), the data is validated against this list using a `typing.Literal` type.  
+**Warning :** this is different from having access to the full CodeSystem. Especially, there is no documentation.  
+**Example :** ValueSet https://www.hl7.org/fhir/valueset-duration-units.html .
+- If a ValueSet is based on a single CodeSystem, this CodeSystem is not included in FHIR specification and the ValueSet is defined as a filter of the fields of the CodeSystem, no specific validation is implemented.  
+**Example :** https://www.hl7.org/fhir/valueset-all-distance-units.html .
+- If a ValueSet is based on several CodeSystems, no specific validation is implemented.
+
+**Note :** when no specific validation is implemented, the attribute has the generic type `FHIRCode` which is a constrained string with the very permissive regex `[^\s]+(\s[^\s]+)*`.
+
+
 # Obsolete
 
 This script does its job for the most part, but it doesn't yet handle all FHIR peculiarities and there's no guarantee the output is correct or complete.

--- a/fhirzeug/fhirrenderer.py
+++ b/fhirzeug/fhirrenderer.py
@@ -24,7 +24,8 @@ class FHIRRenderer:
         self.jinjaenv = Environment(
             loader=PackageLoader(
                 self.generator_config.module, self.generator_config.template.source,
-            )
+            ),
+            extensions=["jinja2.ext.do"],  # Allow the "do" statement in Jinja
         )
         self.jinjaenv.filters["wordwrap"] = do_wordwrap
         self.jinjaenv.filters["snake_case"] = snakecase

--- a/fhirzeug/fhirspec.py
+++ b/fhirzeug/fhirspec.py
@@ -8,7 +8,7 @@ import json
 import datetime
 from pathlib import Path
 import stringcase  # type: ignore
-from typing import Dict, List, Optional, Union, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, Union, TYPE_CHECKING
 
 from .logger import logger
 from . import fhirclass
@@ -94,26 +94,28 @@ class FHIRSpec(object):
                     codesystem = FHIRCodeSystem(self, resource)
                     self.found_codesystem(codesystem)
                 else:
-                    logger.warning(
-                        "CodeSystem with no concepts: {}".format(resource["url"])
-                    )
+                    logger.warning(f"CodeSystem with no concepts: {resource['url']}")
         logger.info(
-            "Found {} ValueSets and {} CodeSystems".format(
-                len(self.valuesets), len(self.codesystems)
-            )
+            f"Found {len(self.valuesets)} ValueSets and {len(self.codesystems)} CodeSystems"
         )
 
     def found_codesystem(self, codesystem):
         if codesystem.url not in self.generator_config.mapping_rules.enum_ignore:
             self.codesystems[codesystem.url] = codesystem
 
-    def valueset_with_uri(self, uri):
+    def valueset_with_uri(self, uri) -> Optional["FHIRValueSet"]:
         assert uri
-        return self.valuesets.get(uri)
+        if uri not in self.valuesets:
+            logger.warning(f"Valueset not found for URI : {uri}")
+            return None
+        return self.valuesets[uri]
 
-    def codesystem_with_uri(self, uri):
+    def codesystem_with_uri(self, uri) -> Optional["FHIRCodeSystem"]:
         assert uri
-        return self.codesystems.get(uri)
+        if uri not in self.codesystems:
+            logger.warning(f"Codesystem not found for URI : {uri}")
+            return None
+        return self.codesystems[uri]
 
     # MARK: Handling Profiles
 
@@ -201,13 +203,13 @@ class FHIRSpec(object):
         if classname is None or len(classname) == 0:
             return None
 
-        # if we have a parent, do we have a mapped class?
-        pathname = (
-            "{}.{}".format(parent_name, classname) if parent_name is not None else None
-        )
         classmap = self.generator_config.mapping_rules.classmap
-        if pathname is not None and pathname in classmap:
-            return classmap[pathname]
+
+        if parent_name is not None:
+            # if we have a parent, do we have a mapped class?
+            pathname = f"{parent_name}.{classname}"
+            if pathname in classmap:
+                return classmap[pathname]
 
         # is our plain class mapped?
         if classname in classmap:
@@ -319,21 +321,28 @@ class FHIRValueSetEnum(object):
     """ Holds on to parsed `FHIRValueSet` properties.
     """
 
-    def __init__(self, name, restricted_to, value_set):
+    def __init__(
+        self,
+        name: str,
+        restricted_to: List[str],
+        value_set: "FHIRValueSet",
+        is_codesystem_known: bool,
+    ):
         self.name = name
         self.restricted_to = restricted_to if len(restricted_to) > 0 else None
         self.value_set = value_set
-        self.represents_class = True  # required for FHIRClass compatibily
-        self.module = name  # required for FHIRClass compatibily
-        self.name_if_class = name  # required for FHIRClass compatibily
-        self.superclass_name = None  # required for FHIRClass compatibily
-        self.path = None  # required for FHIRClass compatibily
+        self.is_codesystem_known = is_codesystem_known
+        self.represents_class = True  # required for FHIRClass compatibility
+        self.module = name  # required for FHIRClass compatibility
+        self.name_if_class = name  # required for FHIRClass compatibility
+        self.superclass_name = None  # required for FHIRClass compatibility
+        self.path = None  # required for FHIRClass compatibility
 
     @property
-    def definition(self):
+    def definition(self) -> "FHIRValueSet":
         return self.value_set
 
-    def name_of_resource(self):  # required for FHIRClass compatibily
+    def name_of_resource(self) -> None:  # required for FHIRClass compatibility
         return None
 
 
@@ -341,7 +350,7 @@ class FHIRValueSet(object):
     """ Holds on to ValueSets bundled with the spec.
     """
 
-    def __init__(self, spec, set_dict):
+    def __init__(self, spec: "FHIRSpec", set_dict: Dict[str, Any]):
         self.spec = spec
         self.definition = set_dict
         self.url = set_dict.get("url")
@@ -356,7 +365,7 @@ class FHIRValueSet(object):
                 "description"
             )
 
-        self._enum = None
+        self._enum: Optional["FHIRValueSetEnum"] = None
 
     @property
     def short(self):
@@ -367,12 +376,46 @@ class FHIRValueSet(object):
         return self.definition.get("description")
 
     @property
-    def enum(self):
+    def enum(self) -> Optional[FHIRValueSetEnum]:
         """ Returns FHIRValueSetEnum if this valueset can be represented by one.
         """
         if self._enum is not None:
             return self._enum
 
+        include = self.__safely_get_single_include()
+        if include is None:
+            return None
+
+        system = include.get("system")
+        if system is None:
+            return None
+
+        # alright, this is a ValueSet with 1 include and a system, is there a CodeSystem?
+        cs = self.spec.codesystem_with_uri(system)
+        is_codesystem_known = True
+        if cs is None or not cs.generate_enum:
+            # If no CodeSystem is found, we build an unofficial enum
+            # Example : system = "http://unitsofmeasure.org" is not defined in FHIR
+            is_codesystem_known = False
+            cs_name = "unknown_codesystem_enum"
+        else:
+            cs_name = cs.name
+
+        # Restrict CodeSystem to subset of concepts
+        restricted_to = []
+        for concept in include.get("concept", []):
+            assert "code" in concept
+            restricted_to.append(concept["code"])
+
+        self._enum = FHIRValueSetEnum(
+            name=cs_name,
+            restricted_to=restricted_to,
+            value_set=self,
+            is_codesystem_known=is_codesystem_known,
+        )
+        return self._enum
+
+    def __safely_get_single_include(self) -> Optional[Dict[str, Any]]:
         include = None
 
         if self.dstu2_inlined_codesystem is not None:
@@ -380,44 +423,22 @@ class FHIRValueSet(object):
         else:
             compose = self.definition.get("compose")
             if compose is None:
-                raise Exception(
-                    f"Currently only composed ValueSets are supported. {self.definition}"
-                )
+                msg = f"Currently only composed ValueSets are supported. {self.definition}"
+                raise Exception(msg)
             if "exclude" in compose:
-                raise Exception("Not currently supporting 'exclude' on ValueSet")
-            include = compose.get("include") or compose.get(
-                "import"
-            )  # "import" is for DSTU-2 compatibility
+                msg = "Not currently supporting 'exclude' on ValueSet"
+                raise Exception(msg)
 
-        if 1 != len(include):
+            # "import" is for DSTU-2 compatibility
+            include = compose.get("include") or compose.get("import") or []
+
+        if len(include) != 1:
             logger.warning(
-                "Ignoring ValueSet with more than 1 includes ({}: {})".format(
-                    len(include), include
-                )
+                f"Ignoring ValueSet with more than 1 includes ({len(include)}: {include})"
             )
             return None
 
-        system = include[0].get("system")
-        if system is None:
-            return None
-
-        # alright, this is a ValueSet with 1 include and a system, is there a CodeSystem?
-        cs = self.spec.codesystem_with_uri(system)
-        if cs is None or not cs.generate_enum:
-            return None
-
-        # do we only allow specific concepts?
-        restricted_to = []
-        concepts = include[0].get("concept")
-        if concepts is not None:
-            for concept in concepts:
-                assert "code" in concept
-                restricted_to.append(concept["code"])
-
-        self._enum = FHIRValueSetEnum(
-            name=cs.name, restricted_to=restricted_to, value_set=self
-        )
-        return self._enum
+        return include[0]
 
 
 class FHIRCodeSystem(object):
@@ -445,12 +466,13 @@ class FHIRCodeSystem(object):
 
         if resource.get("experimental"):
             return
-        self.generate_enum = "complete" == resource["content"]
+
+        if resource["content"] == "complete":
+            self.generate_enum = True
+
         if not self.generate_enum:
-            logger.debug(
-                'Will not generate enum for CodeSystem "{}" whose content is {}'.format(
-                    self.url, resource["content"]
-                )
+            logger.warning(
+                f"Will not generate enum for CodeSystem '{self.url}' whose content is {resource['content']}"
             )
             return
 
@@ -458,9 +480,7 @@ class FHIRCodeSystem(object):
         if len(concepts) > 200:
             self.generate_enum = False
             logger.info(
-                'Will not generate enum for CodeSystem "{}" because it has > 200 ({}) concepts'.format(
-                    self.url, len(concepts)
-                )
+                f"Will not generate enum for CodeSystem '{self.url}' because it has > 200 ({len(concepts)}) concepts"
             )
             return
 
@@ -472,9 +492,7 @@ class FHIRCodeSystem(object):
             if c["code"][:1].isdigit():
                 self.generate_enum = False
                 logger.info(
-                    'Will not generate enum for CodeSystem "{}" because at least one concept code starts with a number'.format(
-                        self.url
-                    )
+                    "Will not generate enum for CodeSystem '{self.url}' because at least one concept code starts with a number"
                 )
                 return None
 
@@ -1046,12 +1064,12 @@ class FHIRStructureDefinitionElementDefinition(object):
             and self.binding.has_valueset
         ):
             uri = self.binding.valueset_uri
-            if "http://hl7.org/fhir" != uri[:19]:
+            if not uri.startswith("http://hl7.org/fhir"):
                 logger.debug('Ignoring foreign ValueSet "{}"'.format(uri))
                 return
+
             # remove version from canonical URI, if present, e.g. "http://hl7.org/fhir/ValueSet/name-use|4.0.0"
-            if "|" in uri:
-                uri = uri.split("|")[0]
+            uri = uri.split("|")[0]
 
             valueset = self.element.profile.spec.valueset_with_uri(uri)
             if valueset is None:

--- a/fhirzeug/generators/python_pydantic/static_files/pyproject.toml
+++ b/fhirzeug/generators/python_pydantic/static_files/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 #    ]
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.8"
 stringcase = "^1.2.0"
 pydantic = "^1.5.1"
 
@@ -35,4 +35,3 @@ pytest-cov = "^2.8.1"
 [build-system]
 requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"
-

--- a/fhirzeug/generators/python_pydantic/static_files/tests/test_examples/test_basic.py
+++ b/fhirzeug/generators/python_pydantic/static_files/tests/test_examples/test_basic.py
@@ -27,3 +27,17 @@ def test_int_types() -> None:
 
     with pytest.raises(pydantic.ValidationError):
         timing_repeat = r4.TimingRepeat(count=0)  # noqa : F841
+
+
+def test_generated_enums() -> None:
+    r4.Account(status="active")
+
+    with pytest.raises(pydantic.ValidationError):
+        # AccountStatus is a `DocEnum` object.
+        account = r4.Account(status="not_a_predefined_status")  # noqa : F841
+
+    r4.TimingRepeat(duration_unit="s")
+
+    with pytest.raises(pydantic.ValidationError):
+        # DurationUnit is a typing.Literal field.
+        repeat = r4.TimingRepeat(duration_unit="not_a_predefined_unit")  # noqa : F841

--- a/fhirzeug/generators/python_pydantic/templates/resource.py.jinja2
+++ b/fhirzeug/generators/python_pydantic/templates/resource.py.jinja2
@@ -23,7 +23,9 @@ class {{ clazz.name }}({{ clazz.superclass.name|default('object')}}):
 {% set enums = [] %}
 {% for prop in clazz.properties %}
     {%- if prop.enum %}
-        {{ enums.append({"name":prop.name, "enum": prop.enum.name}) or ""}}
+        {%- if prop.enum.is_codesystem_known %}
+            {{ enums.append({"name":prop.name, "enum": prop.enum.name}) or ""}}
+        {%- endif %}
     {% endif %}
     {%- set type_name = prop.desired_classname %}
     {%- if not prop.is_native %}
@@ -36,6 +38,15 @@ class {{ clazz.name }}({{ clazz.superclass.name|default('object')}}):
             {%- set type_name = "typing.List[{}]".format(type_name) %}
         {%- endif %}
     {%- endif %}
+    {%- if prop.enum %}
+        {%- if not prop.enum.is_codesystem_known and prop.enum.restricted_to %}
+            {%- set tmp_list = [] %}
+            {%- for code in prop.enum.restricted_to %}
+                {% do tmp_list.append('"' + code + '"') %}
+            {%- endfor %}
+            {%- set type_name = 'typing.Literal[{}]'.format(tmp_list |join(", ")) %}
+        {%- endif %}
+    {% endif %}
     {%- if prop.is_optional or prop.choice_of_type %}{# one of many https://www.hl7.org/fhir/formats.html#choice #}
         {%- set type_name = "typing.Optional[{}]".format(type_name) %}
     {%- endif %}

--- a/fhirzeug/generators/python_pydantic/templates/resource_type.py.jinja2
+++ b/fhirzeug/generators/python_pydantic/templates/resource_type.py.jinja2
@@ -1,8 +1,0 @@
-
-
-FHIRResourceType = typing.Literal[
-  "FHIRAbstractResource",{% for resource_type in resource_types %}
-  "{{resource_type}}",{% endfor %}
-]
-
-

--- a/poetry.lock
+++ b/poetry.lock
@@ -422,6 +422,19 @@ python-versions = "*"
 version = "1.2.0"
 
 [[package]]
+category = "main"
+description = "A collection of helpers and mock objects for unit tests and doc tests."
+name = "testfixtures"
+optional = false
+python-versions = "*"
+version = "6.14.1"
+
+[package.extras]
+build = ["setuptools-git", "wheel", "twine"]
+docs = ["sphinx", "zope.component", "sybil", "twisted", "mock", "django (<2)", "django"]
+test = ["pytest (>=3.6)", "pytest-cov", "pytest-django", "zope.component", "sybil", "twisted", "mock", "django (<2)", "django"]
+
+[[package]]
 category = "dev"
 description = "Python Library for Tom's Obvious, Minimal Language"
 name = "toml"
@@ -484,7 +497,7 @@ python-versions = "*"
 version = "0.1.9"
 
 [metadata]
-content-hash = "0e85b43a53022c613b202cc0b0780c135696e033ca09cc7841b35b469284386b"
+content-hash = "a956978de1bdc6394c48b4089f970d8c169674272191e7a2ce498bf7b8876eec"
 python-versions = "^3.8"
 
 [metadata.files]
@@ -757,6 +770,10 @@ six = [
 ]
 stringcase = [
     {file = "stringcase-1.2.0.tar.gz", hash = "sha256:48a06980661908efe8d9d34eab2b6c13aefa2163b3ced26972902e3bdfd87008"},
+]
+testfixtures = [
+    {file = "testfixtures-6.14.1-py2.py3-none-any.whl", hash = "sha256:30566e24a1b34e4d3f8c13abf62557d01eeb4480bcb8f1745467bfb0d415a7d9"},
+    {file = "testfixtures-6.14.1.tar.gz", hash = "sha256:58d2b3146d93bc5ddb0cd24e0ccacb13e29bdb61e5c81235c58f7b8ee4470366"},
 ]
 toml = [
     {file = "toml-0.10.0-py2.7.egg", hash = "sha256:f1db651f9657708513243e61e6cc67d101a39bad662eaa9b5546f789338e07a3"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ typer = "^0.1.1"
 colorlog = "^4.1.0"
 pyyaml = "^5.3.1"
 stringcase = "^1.2.0"
+testfixtures = "^6.14.1"
 
 [tool.poetry.dev-dependencies]
 black = "^19.10b0"
@@ -26,9 +27,9 @@ pytest-cov = "^2.8.1"
 [tool.poetry.scripts]
 fhirzeug = "fhirzeug.cli:app"
 
+[tool.black]
+exclude = "fhirzeug/generators/python_pydantic/templates/"
 [build-system]
 requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"
 
-[tool.black]
-exclude = "fhirzeug/generators/python_pydantic/templates/"

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,14 @@
+import logging
+from fhirzeug import logger
+from testfixtures import LogCapture
+
+
+def test_setup_logging():
+    """Check FHIRparser logger."""
+    logger.setup_logging()
+    assert logger.logger.level == logging.DEBUG
+
+    with LogCapture() as l:
+        logger.logger.info("Test message")
+
+    l.check(("fhirparser", "INFO", "Test message"),)


### PR DESCRIPTION
Closes #52 .

If a Valueset is defined based on a CodeSystem that is external to FHIR (ex: units system), the Valueset is not encoded as a DocEnum in pydantic_fhir.
However, if CodeSystem is unknown but FHIR specification states the exhaustive list of values that can take the ValueSet, we now use this information to validate the data.

Also done a bit of refactoring.
And also forced Python to be 3.8. I can do separate issue about that if you want to.