### PR TITLE
Remove null objects from list in _without_empty_object

### DIFF
--- a/fhirzeug/generators/python_pydantic/static_files/pyproject.toml
+++ b/fhirzeug/generators/python_pydantic/static_files/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydantic-fhir"
-version = "0.0.1-alpha12"
+version = "0.0.1-alpha14"
 description = "Generated FHIR model for Pydantic."
 readme = "README.md"
 authors = ["Skalar Systems <contact@skalarsystems.com>"]

--- a/fhirzeug/generators/python_pydantic/static_files/pyproject.toml
+++ b/fhirzeug/generators/python_pydantic/static_files/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydantic-fhir"
-version = "0.0.1-alpha14"
+version = "0.0.1-alpha13"
 description = "Generated FHIR model for Pydantic."
 readme = "README.md"
 authors = ["Skalar Systems <contact@skalarsystems.com>"]

--- a/fhirzeug/generators/python_pydantic/static_files/tests/test_examples/test_basic.py
+++ b/fhirzeug/generators/python_pydantic/static_files/tests/test_examples/test_basic.py
@@ -46,7 +46,7 @@ def test_generated_enums() -> None:
 def test_empty_list_serialization() -> None:
     """An empty coding must be ignored during serialization.
 
-    - Expected behavior : "tag" = []
-    - Previous behavior : "tag" = [None]
+    - Expected behavior : {}
+    - Previous behavior : {"tag" = [None]}
     """
-    assert r4.Meta(tag=[r4.Coding()]) == {"tag": []}
+    assert r4.Meta(tag=[r4.Coding()]).dict() == {}

--- a/fhirzeug/generators/python_pydantic/static_files/tests/test_examples/test_basic.py
+++ b/fhirzeug/generators/python_pydantic/static_files/tests/test_examples/test_basic.py
@@ -50,4 +50,3 @@ def test_empty_list_serialization() -> None:
     - Previous behavior : "tag" = [None]
     """
     assert r4.Meta(tag=[r4.Coding()]) == {"tag": []}
-

--- a/fhirzeug/generators/python_pydantic/static_files/tests/test_examples/test_basic.py
+++ b/fhirzeug/generators/python_pydantic/static_files/tests/test_examples/test_basic.py
@@ -45,7 +45,7 @@ def test_generated_enums() -> None:
 
 def test_empty_list_serialization() -> None:
     """An empty coding must be ignored during serialization.
-    
+
     - Expected behavior : "tag" = []
     - Previous behavior : "tag" = [None]
     """

--- a/fhirzeug/generators/python_pydantic/static_files/tests/test_examples/test_basic.py
+++ b/fhirzeug/generators/python_pydantic/static_files/tests/test_examples/test_basic.py
@@ -41,3 +41,13 @@ def test_generated_enums() -> None:
     with pytest.raises(pydantic.ValidationError):
         # DurationUnit is a typing.Literal field.
         repeat = r4.TimingRepeat(duration_unit="not_a_predefined_unit")  # noqa : F841
+
+
+def test_empty_list_serialization() -> None:
+    """An empty coding must be ignored during serialization.
+    
+    - Expected behavior : "tag" = []
+    - Previous behavior : "tag" = [None]
+    """
+    assert r4.Meta(tag=[r4.Coding()]) == {"tag": []}
+

--- a/fhirzeug/generators/python_pydantic/templates/resource_header.py
+++ b/fhirzeug/generators/python_pydantic/templates/resource_header.py
@@ -129,7 +129,8 @@ def _without_empty_items(obj: typing.Any):
         return obj
 
     if isinstance(obj, (list, tuple)):
-        cleaned_list = [_without_empty_items(item) for item in obj]
+        cleaned_list_with_none = [_without_empty_items(item) for item in obj]
+        cleaned_list = [item for item in cleaned_list_with_none if item is not None]
         if cleaned_list:
             return cleaned_list
         return None

--- a/tests/pydantic/test_json_serialization.py
+++ b/tests/pydantic/test_json_serialization.py
@@ -5,6 +5,7 @@ import pytest
 
 from fhirzeug.generators.python_pydantic.templates.resource_header import (
     FHIRAbstractBase,
+    _without_empty_items,
 )
 
 
@@ -34,3 +35,17 @@ def test_decimal_serialization(input, expected):
 
     if input:
         assert str(ExampleModel.parse_raw(serialized).decimal) == str(input)
+
+
+@pytest.mark.parametrize(
+    ("input", "expected"),
+    [
+        ([], None),
+        ([None], None),
+        ({"empty": None}, None),
+        ([{"empty": None}], None),
+        ([{"empty": [], "example": "example"}], [{"example": "example"}]),
+    ],
+)
+def test_without_empty_items(input: typing.Any, expected: typing.Any):
+    assert _without_empty_items(input) == expected

--- a/tests/pydantic/test_nullability.py
+++ b/tests/pydantic/test_nullability.py
@@ -1,8 +1,5 @@
 import typing
 
-import pydantic
-import pytest
-
 from fhirzeug.generators.python_pydantic.templates.fhir_basic_types import FHIRString
 from fhirzeug.generators.python_pydantic.templates.resource_header import (
     FHIRAbstractBase,

--- a/tests/pydantic/test_nullability.py
+++ b/tests/pydantic/test_nullability.py
@@ -68,41 +68,45 @@ def test_empty_lists_are_ignored():
     assert RootModel(field_a="a", list_items=[]).dict() == {
         "field_a": "a",
     }
-    with pytest.raises(pydantic.ValidationError):
-        RootModel(**{"field_a": "a", "list_items": [{}, {}, {}]})
+    assert RootModel(**{"field_a": "a", "list_items": [{}, {}, {}]}).list_items is None
 
 
 def test_non_empty_list_items_are_serialized():
-    with pytest.raises(pydantic.ValidationError):
-        RootModel(
-            **{
-                "field_a": "a",
-                "list_items": [
-                    {"list_field_a": "list item 1 a"},
-                    {},
-                    {"list_field_a": "list item 3 a"},
-                ],
-            }
+    assert (
+        len(
+            RootModel(
+                **{
+                    "field_a": "a",
+                    "list_items": [
+                        {"list_field_a": "list item 1 a"},
+                        {},
+                        {"list_field_a": "list item 3 a"},
+                    ],
+                }
+            ).list_items
         )
+        == 2
+    )
 
 
 def test_none_items_cannot_be_in_lists():
-    with pytest.raises(pydantic.ValidationError):
-        RootModel(
-            field_a="a",
-            list_items=[
-                ListItem(list_field_a="list item 1 a"),
-                None,
-                ListItem(list_field_a="list item 3 a"),
-            ],
+    assert (
+        len(
+            RootModel(
+                field_a="a",
+                list_items=[
+                    ListItem(list_field_a="list item 1 a"),
+                    None,
+                    ListItem(list_field_a="list item 3 a"),
+                ],
+            ).list_items
         )
+        == 2
+    )
 
 
 def test_none_items_in_lists():
-    with pytest.raises(pydantic.ValidationError):
-        RootModel(
-            field_a="a", list_items=[None],
-        )
+    assert RootModel(field_a="a", list_items=[None],).list_items is None
 
 
 def test_none_as_list():


### PR DESCRIPTION
I detected a new bug when working on the `tag` attribute. At the moment, the behavior of `_without_empty_object` is as follow :
- if a list is empty : return None
- if a list has an object that is empty : return the list with a None inside
I think the behavior would be to remove the item from the list, otherwise it creates a List that is not consistent.

My use case :
```
code = r4.Coding() # No error since all fields are optional
meta = r4.Meta(tag=[code]) 
meta.dict() # Throws an error instead of an empty dictionnary
```